### PR TITLE
Added notes about PyCon and EuroPython web assembly summits.

### DIFF
--- a/meetings/2024/webassembly-summit-europython.md
+++ b/meetings/2024/webassembly-summit-europython.md
@@ -42,7 +42,7 @@ The following topics were discussed (taken from notes provided by Chris Laffra):
 * Pyodide focused:
     * Reducing the footprint, compression - do like Pyrun (remove stuff, compress).
     * Reducing startup time:
-        * We need to improve packages to download all dependencies at once, rather than one wheel at a time.
+        * We need to improve packages to download all dependencies at once, rather than one wheel at a time. [Previous online context/discussion](https://github.com/pyodide/pyodide/issues/2045#issuecomment-1423248534).
         * We should parallelize startup and package downloads.
         * Cache entire file-system as a snapshot with all packages pre-installed (an idea from Nicholas).
         * Related: memory snapshots.

--- a/meetings/2024/webassembly-summit-europython.md
+++ b/meetings/2024/webassembly-summit-europython.md
@@ -1,0 +1,50 @@
+# EuroPython 2024 Web Assembly Summit
+
+Held in Prague. Event website here: https://ep2024.europython.eu/session/webassembly-summit 
+
+We had around 15 sign up, and several more turn up on the day.
+
+As last yeat, the morning consisted of presentations, with a discussion
+scheduled for the afternoon.
+
+## Presentations
+
+The talks presented in the morning were:
+
+* Patrick Armino: presenting Strawberry rocks (cancelled).
+* Chris Laffra: PySheets and/or profiling with PyScript.
+* Hood Chatham: State of the Pyodide Union.
+* Josh Lowe: Migrating Edublocks to PyScript.
+* Antonio Cuni: SPy summary.
+* Nicholas Tollervey: State of PyScript Union.
+
+
+These were presented in a "seminar fashion" where people were encouraged to
+respectfully interrupt, question, debate and otherwise constructively engage
+during the presentation of the subject matter.
+
+## Afternoon discussion
+
+The following topics were discussed (taken from notes provided by Chris Laffra):
+
+* WASM specific:
+    * WASI -> Arjun Ramesh and Ben Titzer's WALI (Web Assembly Linux Interface): niche, light-weight and secure "docker" for WASM. [Proposal paper](https://www.semanticscholar.org/paper/Stop-Hiding-The-Sharp-Knives%3A-The-WebAssembly-Linux-Ramesh-Huang/2544ea6d1cb37723b3988b7874981048357a614d)
+* PyScript related:
+    * UI toolkits:
+        * [Invent](https://inventframework.org/), `pyscript.web` API ([docs](https://docs.pyscript.net/2024.8.2/user-guide/dom/#pyscriptweb)), [puepi](https://puepy.dev/))
+        * [Pygame Zero](https://pygame-zero.readthedocs.io/en/stable/index.html) - can we run it in PyScript? Performance is the challenge.
+            * **TODO**: we should create an FFI-aware kernel to run games (like PGZero).
+            * Check out [Streamlit](https://streamlit.io/).
+        * PyScript [LTK](https://github.com/pyscript/ltk) - client side rendering of UIs on top of jQuery and PyScript.
+        * Integration with JS frameworks:
+            * [HTMXXX](https://htmxxx.fly.dev/)
+            * Jinja templates to JS?
+* Pyodide focused:
+    * Reducing the footprint, compression - do like Pyrun (remove stuff, compress).
+    * Reducing startup time:
+        * We need to improve packages to download all dependencies at once, rather than one wheel at a time.
+        * We should parallelize startup and package downloads.
+        * Cache entire file-system as a snapshot with all packages pre-installed (an idea from Nicholas).
+        * Related: memory snapshots.
+        * WASM-fs will improve things, rather than the current JS version.
+    * Nightly packages are now a thing.

--- a/meetings/2024/webassembly-summit-europython.md
+++ b/meetings/2024/webassembly-summit-europython.md
@@ -4,7 +4,7 @@ Held in Prague. Event website here: https://ep2024.europython.eu/session/webasse
 
 We had around 15 sign up, and several more turn up on the day.
 
-As last yeat, the morning consisted of presentations, with a discussion
+As with last year, the morning consisted of presentations, with a discussion
 scheduled for the afternoon.
 
 ## Presentations

--- a/meetings/2024/webassembly-summit-pycon-us.md
+++ b/meetings/2024/webassembly-summit-pycon-us.md
@@ -14,7 +14,7 @@ Organisers:
 
 * Pyodide (Dr. Hood Chatham) - An update on the current state of Pyodide (CPython compiled to WASM) by Hood, a core maintainer of the project.
     * [Blog post with updates](https://blog.pyodide.org/posts/0.26-release/)
-* MicroPython (Dr.Damien George) - A pre-recorded video updating us on the current state of MicroPython compiled to web assembly.
+* MicroPython (Dr. Damien George) - A pre-recorded video updating us on the current state of MicroPython compiled to web assembly.
     * [Unlisted YouTube version](https://youtu.be/6icY5Pq3NOM)
 * WASI and Python (Eric Snow/Dawn Wages/Mike Droettboom) - An outline of the current state of WASI (WebAssembly System Interface) support in CPython.
     * [Tier 2 support is here](https://discuss.python.org/t/wasi-has-been-promoted-to-a-tier-2-platform/45525)

--- a/meetings/2024/webassembly-summit-pycon-us.md
+++ b/meetings/2024/webassembly-summit-pycon-us.md
@@ -4,7 +4,7 @@
 
 Organisers:
 
-* Dr.Brett Cannon - Microsoft
+* Dr. Brett Cannon - Microsoft
 * Fabio Pliger - Anaconda
 * Nicholas Tollervey - Anaconda
 

--- a/meetings/2024/webassembly-summit-pycon-us.md
+++ b/meetings/2024/webassembly-summit-pycon-us.md
@@ -20,7 +20,7 @@ Organisers:
     * [Tier 2 support is here](https://discuss.python.org/t/wasi-has-been-promoted-to-a-tier-2-platform/45525)
 * PyScript (Fabio Pliger) - Updates, developments, future plans in the world of PyScript (a platform for Python in the browser).
     * [PyScript homepage](https://pyscript.net)
-* PySheets / LTK (Dr.Chris Laffra) - a demonstration and description of PySheets - a spreadsheet UI for notebook like coding, written with PyScript.
+* PySheets / LTK (Dr. Chris Laffra) - a demonstration and description of PySheets - a spreadsheet UI for notebook like coding, written with PyScript.
     * [LTK](https://github.com/pyscript/ltk)
     * [PySheets](https://pysheets.app/)
 * Using Web Assembly to Teach Code Generation in an Undergraduate Compiler Design Course (Ariel Ortiz) - With the Arpeggio and wasmtime Python packages it is possible to use a vertical slice approach in order to teach how to build incrementally a fully working compiler in just under 16 hrs. The language being compiled supports only one data type (32 bit integer), arithmetic, relational, and logic operators, variables, and also conditional and loop statements. The target language is the WebAssembly text format.

--- a/meetings/2024/webassembly-summit-pycon-us.md
+++ b/meetings/2024/webassembly-summit-pycon-us.md
@@ -1,0 +1,36 @@
+# WebAssembly Summit at PyCon US 2024 - Pittsburgh
+
+[Website](https://us.pycon.org/2024/events/webassembly-summit/)
+
+Organisers:
+
+* Dr.Brett Cannon - Microsoft
+* Fabio Pliger - Anaconda
+* Nicholas Tollervey - Anaconda
+
+## Agenda
+
+### Morning - talks MC'd by Nicholas
+
+* Pyodide (Dr.Hood Chatham) - An update on the current state of Pyodide (CPython compiled to WASM) by Hood, a core maintainer of the project.
+    * [Blog post with updates](https://blog.pyodide.org/posts/0.26-release/)
+* MicroPython (Dr.Damien George) - A pre-recorded video updating us on the current state of MicroPython compiled to web assembly.
+    * [Unlisted YouTube version](https://youtu.be/6icY5Pq3NOM)
+* WASI and Python (Eric Snow/Dawn Wages/Mike Droettboom) - An outline of the current state of WASI (WebAssembly System Interface) support in CPython.
+    * [Tier 2 support is here](https://discuss.python.org/t/wasi-has-been-promoted-to-a-tier-2-platform/45525)
+* PyScript (Fabio Pliger) - Updates, developments, future plans in the world of PyScript (a platform for Python in the browser).
+    * [PyScript homepage](https://pyscript.net)
+* PySheets / LTK (Dr.Chris Laffra) - a demonstration and description of PySheets - a spreadsheet UI for notebook like coding, written with PyScript.
+    * [LTK](https://github.com/pyscript/ltk)
+    * [PySheets](https://pysheets.app/)
+* Using Web Assembly to Teach Code Generation in an Undergraduate Compiler Design Course (Ariel Ortiz) - With the Arpeggio and wasmtime Python packages it is possible to use a vertical slice approach in order to teach how to build incrementally a fully working compiler in just under 16 hrs. The language being compiled supports only one data type (32 bit integer), arithmetic, relational, and logic operators, variables, and also conditional and loop statements. The target language is the WebAssembly text format.
+
+### Afternoon - unconference discussion MC'd by Fabio
+
+* ???
+
+## Other PyCon WASM Activity
+
+* [Making Your Documentation Interactive with PyScript](https://us.pycon.org/2024/schedule/presentation/92/) - Jeff Glass
+* [Interactive Software Documentation, with PyScript](https://us.pycon.org/2024/schedule/presentation/115/) - Valerio Maggio
+* [Build in-browser 3D experiences with WebGL and PyScript](https://us.pycon.org/2024/schedule/presentation/139/) - Łukasz Langa

--- a/meetings/2024/webassembly-summit-pycon-us.md
+++ b/meetings/2024/webassembly-summit-pycon-us.md
@@ -12,7 +12,7 @@ Organisers:
 
 ### Morning - talks MC'd by Nicholas
 
-* Pyodide (Dr.Hood Chatham) - An update on the current state of Pyodide (CPython compiled to WASM) by Hood, a core maintainer of the project.
+* Pyodide (Dr. Hood Chatham) - An update on the current state of Pyodide (CPython compiled to WASM) by Hood, a core maintainer of the project.
     * [Blog post with updates](https://blog.pyodide.org/posts/0.26-release/)
 * MicroPython (Dr.Damien George) - A pre-recorded video updating us on the current state of MicroPython compiled to web assembly.
     * [Unlisted YouTube version](https://youtu.be/6icY5Pq3NOM)


### PR DESCRIPTION
Fixes #6

NB: These should have been written up sooner (my apologies). But life, the universe and everything got in the way. This may explain their rather sketchy nature. I've included appropriate links where possible.